### PR TITLE
feat: Add adminCommand database method

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ See https://docs.mongodb.com/manual/reference/method/db.runCommand/
 
 #### `db.adminCommand(command)`
 
-See https://docs.mongodb.com/manual/reference/method/db.adminCommand/
+See https://mongodb.github.io/node-mongodb-native/3.3/api/Db.html#executeDbAdminCommand
 
 #### `db.stats()`
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ const result = await db.things.runCommand('count');
 console.log(result);
 ```
 
+Similarly, you can use `db.adminCommand()` to run a command on the `admin` database of the
+MongoDB cluster or instance you're connected to:
+
+```js
+const result = await db.adminCommand({currentOp: 1});
+console.log(result);
+```
+
 ### Replication Sets
 
 Mongoist can connect to a mongo replication set by providing a connection string with multiple hosts
@@ -450,6 +458,11 @@ See https://docs.mongodb.com/manual/reference/method/db.getLastErrorObj/
 #### `db.runCommand(command)`
 
 See https://docs.mongodb.com/manual/reference/method/db.runCommand/
+
+
+#### `db.adminCommand(command)`
+
+See https://docs.mongodb.com/manual/reference/method/db.adminCommand/
 
 #### `db.stats()`
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -4,6 +4,10 @@ const urlParser = require('mongodb/lib/url_parser.js');
 const Collection = require('./collection');
 const debug = require('debug')('mongoist');
 
+function normalizeCommandOpts(opts) {
+  return typeof opts === 'string' ? { [opts]: 1 } : opts;
+}
+
 module.exports = class Database extends EventEmitter {
   constructor(connectionString, options) {
     super();
@@ -48,6 +52,12 @@ module.exports = class Database extends EventEmitter {
     return this.listCollections().then(collections => collections.map((collection) => collection.name));
   }
 
+  adminCommand(opts) {
+    return this
+      .connect()
+      .then(connection => connection.executeDbAdminCommand(normalizeCommandOpts(opts)));
+  }
+
   runCommand(opts) {
     if (typeof opts === 'string') {
       opts = {
@@ -56,7 +66,7 @@ module.exports = class Database extends EventEmitter {
 
     return this
       .connect()
-      .then(connection => connection.command(opts));
+      .then(connection => connection.command(normalizeCommandOpts(opts)));
   }
 
   stats(scale) {

--- a/test/database.js
+++ b/test/database.js
@@ -296,4 +296,9 @@ describe('database', function() {
     await db.close();
     await db2.close();
   });
+
+  it('should execute admin commands', async() => {
+    const dbStats = await db.adminCommand({ dbStats: 1 });
+    expect(dbStats.db).to.equal('admin');
+  })
 });


### PR DESCRIPTION
To run admin commands like `db.adminCommand({ dbStats: 1 })` we want to
wrap the underlying driver's admin command function.