### PR TITLE
Add useUnifiedTopology to MongoClient constructor.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -112,7 +112,7 @@ module.exports = class Database extends EventEmitter {
         .then(parsedUrl => parsedUrl.dbName)
         .then(dbName => {
           return mongodb.MongoClient
-            .connect(this.connectionString, { useNewUrlParser: true }, this.options)
+            .connect(this.connectionString, { useNewUrlParser: true, useUnifiedTopology: true }, this.options)
             .then(client => {
 
               this.client = client;


### PR DESCRIPTION
Add fix for deprecation warning from MongoClient constructor.

(node:173296) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.

