### PR TITLE
feat(connect): support promise for connectionString

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ not yet opened database connection:
 module.exports = mongoist(connectionString);
 ```
 
+Along these same lines, connection information may not be available synchronously. The connection
+information provided to `mongoist` can be contained in a `Promise`, affording for gathering the
+connection information from arbitrary sources (e.g. `mongo-memory-server`):
+
+```javascript
+module.exports = mongoist(Promise.resolve());
+```
+
 ## Usage
 
 _Please note: Any line in the examples that uses the await keyword should be called inside an async function. If you haven't used async/await yet, you'll want to do some research to help you understand how it works. Or take a look at https://ponyfoo.com/articles/understanding-javascript-async-await for a great read about async/await_

--- a/lib/database.js
+++ b/lib/database.js
@@ -11,11 +11,11 @@ function normalizeCommandOpts(opts) {
 function normalizeConnectionString(connectionString) {
   // Fix short cut connection URLs consisting only of a db name or db + host
   if (connectionString.indexOf('/') < 0) {
-    connectionString = 'localhost:27017/' + connectionString
+    connectionString = 'localhost:27017/' + connectionString;
   }
 
   if (connectionString.indexOf('mongodb://') < 0 && connectionString.indexOf('mongodb+srv://') < 0) {
-    connectionString = 'mongodb://' + connectionString
+    connectionString = 'mongodb://' + connectionString;
   }
 
   return connectionString;

--- a/lib/database.js
+++ b/lib/database.js
@@ -8,19 +8,45 @@ function normalizeCommandOpts(opts) {
   return typeof opts === 'string' ? { [opts]: 1 } : opts;
 }
 
+function normalizeConnectionString(connectionString) {
+  // Fix short cut connection URLs consisting only of a db name or db + host
+  if (connectionString.indexOf('/') < 0) {
+    connectionString = 'localhost:27017/' + connectionString
+  }
+
+  if (connectionString.indexOf('mongodb://') < 0 && connectionString.indexOf('mongodb+srv://') < 0) {
+    connectionString = 'mongodb://' + connectionString
+  }
+
+  return connectionString;
+}
+
+/**
+ * Check whether the given value has a then method. This check classifies whether the value is a
+ * thenable per the Promises/A+ spec, which we use as a reasonable test for whether a given value
+ * is a promise. This method is preferrable to `instanceof Promise` because there are many possible
+ * implementations of the `Promise` prototype (such as `bluebird`, `Q` etc) that we can't
+ * exhaustively test for. Given the context/documentation, we don't expect other objects that we 
+ * could confuse for promises.
+ *
+ * @param {*} value The value to check.
+ * @return {boolean} Whether the given value is thenable.
+ */
+function isThenable(value) {
+  return !!value && typeof value === 'object' && typeof value.then === 'function';
+}
+
 module.exports = class Database extends EventEmitter {
   constructor(connectionString, options) {
     super();
 
-    if (typeof connectionString == 'string') {
-        // Fix short cut connection URLs consisting only of a db name or db + host
-        if (connectionString.indexOf('/') < 0) {
-          connectionString = 'localhost:27017/' + connectionString
-        }
-
-        if (connectionString.indexOf('mongodb://') < 0 && connectionString.indexOf('mongodb+srv://') < 0) {
-          connectionString = 'mongodb://' + connectionString
-        }
+    if (typeof connectionString === 'string') {
+      connectionString = normalizeConnectionString(connectionString);
+    } else if (isThenable(connectionString)) {
+      connectionString = connectionString.then(connectionString =>
+        typeof connectionString === 'string'
+          ? normalizeConnectionString(connectionString)
+          : connectionString);
     }
 
     this.connectionString = connectionString;
@@ -161,6 +187,12 @@ module.exports = class Database extends EventEmitter {
 
         return this.connection;
       });
+    } else if (isThenable(this.connectionString)) {
+      return Promise.resolve(this.connectionString)
+        .then(connectionString => {
+          this.connectionString = connectionString;
+          return this.connect();
+        });
     }
   }
 

--- a/test/database.js
+++ b/test/database.js
@@ -209,9 +209,40 @@ describe('database', function() {
   });
 
 
+  it('should allow passing in a Promise<string>', async () => {
+    const db = mongoist(Promise.resolve(connectionString));
+
+    const docs = await db.a.find({});
+
+    expect(docs).to.have.length(4);
+
+    await db.close();
+  });
+
+  it('should normalize a Promise<string> connectionString', async () => {
+    const dbShort = mongoist(Promise.resolve('localhost:27017/test'));
+    const docs = await dbShort.a.find();
+
+    expect(docs).to.have.length(4);
+
+    await dbShort.close();
+  });
+
   it('should allow passing in a mongojs connection', async() => {
     const mongojsDb = mongojs(connectionString);
     const db = mongoist(mongojsDb);
+
+    const docs = await db.a.find({});
+
+    expect(docs).to.have.length(4);
+
+    await mongojsDb.close();
+    await db.close();
+  });
+
+  it('should allow passing in a Promise that resolves to a mongojs connection', async() => {
+    const mongojsDb = mongojs(connectionString);
+    const db = mongoist(Promise.resolve(mongojsDb));
 
     const docs = await db.a.find({});
 


### PR DESCRIPTION
There are cases where it's useful to have a synchronous reference to the `Database`, and where the connection information is not yet available - particularly in test cases where you may be launching a temporary mongo database using `mongo-memory-server`. To better support this use-case, the `Database` class can accept and store the `connectionString` parameter as a `Promise`, and resolve it to its value in the connect handler which is already well-positioned to wait for asynchronous resolution.