### PR TITLE
fix: report `writeErrors` for bulk ops

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -83,6 +83,13 @@ class Bulk {
     const setResult = (cmd, cmdResult) => {
       const cmdKey = Object.keys(cmd)[0];
       result[this.cmdKeys[cmdKey]] += cmdResult.n;
+      // Collate and report writeErrors to the result object; forgo doing the same for writeConcernErrors
+      // since the node driver throws on writeConcernErrors rather than returning them here.
+      if (cmdResult.writeErrors) {
+        for (const writeError of cmdResult.writeErrors) {
+          result.writeErrors.push(writeError);
+        }
+      }
     }
 
     return this

--- a/test/bulk.js
+++ b/test/bulk.js
@@ -167,4 +167,23 @@ describe('bulk', function() {
     expect(json.nRemoveOps).to.equal(1, 'Should result in nRemoveOps field set to 1');
     expect(json.nBatches).to.equal(3, 'Should result in nBatches field set to 3');
   });
+
+  it('should collate and report writeErrors', async () => {
+    await db.b.createIndex(
+      {
+        name: 1,
+      },
+      {
+        unique: true,
+        background: true,
+      }
+    );
+
+    const bulk = db.b.initializeUnorderedBulkOp();
+    bulk.insert({ name: 'Charmander' });
+    bulk.insert({ name: 'Charmander' });
+    const result = await bulk.execute();
+    expect(result.writeErrors.length).to.equal(1);
+    expect(result.writeErrors[0].errmsg).to.match(/duplicate key error/);
+  });
 });


### PR DESCRIPTION
Collates the `writeErrors` reported by bulk operations and returns them in the
`result` object.

We chose to not do the same for `writeConcernErrors`, as our testing indicated
that the driver throws on write concern errors rather than returning them.