### PR TITLE
fix(types): use correct count function definition

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -451,14 +451,6 @@ type AggregationOptions = $ReadOnly<{|
   session?: ClientSession,
 |}>;
 
-declare type CursorCountOptions = $ReadOnly<{|
-  skip?: number,
-  limit?: number,
-  maxTimeMS?: number,
-  hint?: string,
-  readPreference?: ReadPreference,
-|}>;
-
 // https://github.com/facebook/flow/issues/2753
 declare export class Cursor<Doc> extends stream$Readable {
   constructor(cursorFactory: () => Promise<InternalCursor>): Cursor<Doc>;

--- a/index.js.flow
+++ b/index.js.flow
@@ -467,7 +467,7 @@ declare export class Cursor<Doc> extends stream$Readable {
   batchSize(value: number): this;
   close(): Promise<mixed>;
   collation(value: CollationParam): this;
-  count(applySkipLimit: boolean, options: CursorCountOptions): Promise<number>;
+  count(): Promise<number>;
   destroy(): Promise<mixed>;
   explain(): Promise<mixed>;
   forEach(fn: (doc: Doc) => mixed): Promise<void>;


### PR DESCRIPTION
Based on the [definition](https://github.com/mongoist/mongoist/blob/master/lib/cursor.js#L62), count does not take any arguments and returns a promise that resolves to a number. Flow should reflect that.