### PR TITLE
Fix connection options is ignore with mongodb 3.0+

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -138,7 +138,7 @@ module.exports = class Database extends EventEmitter {
         .then(parsedUrl => parsedUrl.dbName)
         .then(dbName => {
           return mongodb.MongoClient
-            .connect(this.connectionString, { useNewUrlParser: true, useUnifiedTopology: true }, this.options)
+            .connect(this.connectionString, Object.assign(this.options || {}, { useNewUrlParser: true, useUnifiedTopology: true }))
             .then(client => {
 
               this.client = client;

--- a/lib/database.js
+++ b/lib/database.js
@@ -137,9 +137,8 @@ module.exports = class Database extends EventEmitter {
       return parseUrl(this.connectionString, this.options)
         .then(parsedUrl => parsedUrl.dbName)
         .then(dbName => {
-          const combinedOptions = Object.assign(this.options || {}, { useNewUrlParser: true, useUnifiedTopology: true });
           return mongodb.MongoClient
-            .connect(this.connectionString, combinedOptions)
+            .connect(this.connectionString, Object.assign(this.options, { useNewUrlParser: true, useUnifiedTopology: true }))
             .then(client => {
 
               this.client = client;

--- a/lib/database.js
+++ b/lib/database.js
@@ -137,8 +137,9 @@ module.exports = class Database extends EventEmitter {
       return parseUrl(this.connectionString, this.options)
         .then(parsedUrl => parsedUrl.dbName)
         .then(dbName => {
+          const combinedOptions = Object.assign(this.options || {}, { useNewUrlParser: true, useUnifiedTopology: true });
           return mongodb.MongoClient
-            .connect(this.connectionString, Object.assign(this.options || {}, { useNewUrlParser: true, useUnifiedTopology: true }))
+            .connect(this.connectionString, combinedOptions)
             .then(client => {
 
               this.client = client;

--- a/test/database.js
+++ b/test/database.js
@@ -59,6 +59,23 @@ describe('database', function() {
     await dbShort.close();
   });
 
+  it('should accept connection with options', async () => {
+    // auth should fail with invalid 'authSource', to make sure options take effect
+    const cannotConnect = mongoist('localhost:27017/test', { 'authSource': 'dummy' });
+    let errorEvent = null;
+    cannotConnect.on('error', (error) => {
+      errorEvent = error;
+    });
+
+    try {
+      await cannotConnect.test.find();
+      await cannotConnect.close();
+    } catch (e) {
+      expect(errorEvent).to.exist;
+      return;
+    }
+  });
+
   it('should create a collection', async() => {
     const collection = await db.createCollection('test123');
 

--- a/test/database.js
+++ b/test/database.js
@@ -62,19 +62,13 @@ describe('database', function() {
   it('should accept connection with options', async () => {
     // auth should fail with invalid 'authSource', to make sure options take effect
     const cannotConnect = mongoist('localhost:27017/test', { 'authSource': 'dummy' });
-    let errorEvent = null;
-    cannotConnect.on('error', (error) => {
-      errorEvent = error;
-    });
-
     try {
       await cannotConnect.test.find();
       await cannotConnect.close();
+      expect(false, "the error should occurred before");
     } catch (e) {
       expect(e).to.exist;
       return;
-    } finally {
-      expect(errorEvent).to.exist;
     }
   });
 

--- a/test/database.js
+++ b/test/database.js
@@ -60,7 +60,7 @@ describe('database', function() {
   });
 
   it('should accept connection with options', async () => {
-    // auth should fail with invalid 'authSource', to make sure options take effect
+    // connect should fail with enable 'ssl', to make sure options take effect
     const cannotConnect = mongoist('localhost:27017/test', { 'ssl': true });
     
     let err;

--- a/test/database.js
+++ b/test/database.js
@@ -61,15 +61,17 @@ describe('database', function() {
 
   it('should accept connection with options', async () => {
     // auth should fail with invalid 'authSource', to make sure options take effect
-    const cannotConnect = mongoist('localhost:27017/test', { 'authSource': 'dummy' });
+    const cannotConnect = mongoist('localhost:27017/test', { 'authSource': 'invalid_source' });
+    
+    let err;
     try {
       await cannotConnect.test.find();
       await cannotConnect.close();
-      expect(false, "the error should occurred before");
     } catch (e) {
-      expect(e).to.exist;
-      return;
+      err = e;
     }
+    
+    expect(err).to.exist;
   });
 
   it('should create a collection', async() => {

--- a/test/database.js
+++ b/test/database.js
@@ -61,7 +61,7 @@ describe('database', function() {
 
   it('should accept connection with options', async () => {
     // auth should fail with invalid 'authSource', to make sure options take effect
-    const cannotConnect = mongoist('localhost:27017/test', { 'authSource': 'invalid_source' });
+    const cannotConnect = mongoist('localhost:27017/test', { 'ssl': true });
     
     let err;
     try {

--- a/test/database.js
+++ b/test/database.js
@@ -71,8 +71,10 @@ describe('database', function() {
       await cannotConnect.test.find();
       await cannotConnect.close();
     } catch (e) {
-      expect(errorEvent).to.exist;
+      expect(e).to.exist;
       return;
+    } finally {
+      expect(errorEvent).to.exist;
     }
   });
 


### PR DESCRIPTION
When create a connection by mongoist, e.g. mongoist(url, options)

The options doesn't take effect when passing intoMongoClient.connect as the 3rd parameter. Refer to [link](https://mongodb.github.io/node-mongodb-native/3.6/api/lib_mongo_client.js.html).