### PR TITLE
chore: fix flow error and add to CI

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/index.js.flow
+++ b/index.js.flow
@@ -460,7 +460,7 @@ declare export class Cursor<Doc> extends stream$Readable {
   close(): Promise<mixed>;
   collation(value: CollationParam): this;
   count(): Promise<number>;
-  destroy(): Promise<mixed>;
+  destroy(): this;
   explain(): Promise<mixed>;
   forEach(fn: (doc: Doc) => mixed): Promise<void>;
   getCursor(): Promise<InternalCursor>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoist",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mongoist",
       "version": "2.5.4",
       "license": "ISC",
       "dependencies": {
@@ -23,6 +24,7 @@
         "eslint": "^6.5.1",
         "eslint-config-prettier": "^6.10.0",
         "eslint-plugin-flowtype": "^4.6.0",
+        "flow-bin": "0.108.0",
         "mocha": "^6.2.1",
         "mongojs": "^3.0.0",
         "nyc": "^14.1.1",
@@ -3802,6 +3804,18 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "node_modules/flow-bin": {
+      "version": "0.108.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.108.0.tgz",
+      "integrity": "sha512-hPEyCP1J8rdhNDfCAA5w7bN6HUNBDcHVg/ABU5JVo0gUFMx+uRewpyEH8LlLBGjVQuIpbaPpaqpoaQhAVyaYww==",
+      "dev": true,
+      "bin": {
+        "flow": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/foreground-child": {
       "version": "1.5.6",
@@ -11312,6 +11326,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
+    },
+    "flow-bin": {
+      "version": "0.108.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.108.0.tgz",
+      "integrity": "sha512-hPEyCP1J8rdhNDfCAA5w7bN6HUNBDcHVg/ABU5JVo0gUFMx+uRewpyEH8LlLBGjVQuIpbaPpaqpoaQhAVyaYww==",
       "dev": true
     },
     "foreground-child": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoist",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Mongodb driver inspired by mongojs built with async/await in mind",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "nyc --reporter=lcov mocha --recursive --require @babel/polyfill --require @babel/register",
     "test:coveralls": "npm run test",
-    "lint": "eslint . --ext '.js, .js.flow'",
+    "lint": "eslint . --ext '.js, .js.flow' && flow",
     "ci": "npm run lint && npm run test:coveralls",
     "lint:fix": "npm run lint -- --fix",
     "release": "standard-version"
@@ -53,6 +53,7 @@
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-flowtype": "^4.6.0",
+    "flow-bin": "0.108.0",
     "mocha": "^6.2.1",
     "mongojs": "^3.0.0",
     "nyc": "^14.1.1",


### PR DESCRIPTION
When running flow server `v0.108.0` on third-party projects, I got the following error:

![image](https://user-images.githubusercontent.com/11169832/184784363-e268b493-9d74-4eab-a5ce-8422ae753879.png)

This PR fixes the error and adds `flow-bin` to execute on `npm run lint` and prevent future errors to go unnoticed.