### PR TITLE
chore(ci): update persisted credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3


### PR DESCRIPTION
Following the directions [here](https://github.com/cycjimmy/semantic-release-action#basic-usage) to use the access token rather than the checkout credentials