### PR TITLE
chore(ci)!: limit supported mongo versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        mongodb-version: ['2.6.12', '3.0.15','3.2.16','3.4.7','3.6.2','4.0']
+        mongodb-version: ['4.2', '4.4', '5.0', '6.0']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Mongoist driver is heavily inspired by mongojs.
 [![Node.js CI](https://github.com/mongoist/mongoist/actions/workflows/node.js.yml/badge.svg)](https://github.com/mongoist/mongoist/actions/workflows/node.js.yml)
 [![Coverage Status](https://coveralls.io/repos/github/mongoist/mongoist/badge.svg?branch=master)](https://coveralls.io/github/mongoist/mongoist?branch=master)
 
+
+### Requirements
+
+Mongoist works with currently supported stable versions of [`mongodb`](https://www.mongodb.com/support-policy/lifecycles) and [`node`](https://github.com/nodejs/Release).
+
+**Mongodb Version:** 4.2, 4.4, 5.0, 6.0
+
+**Node.js Version:** 14.x, 16.x, 18.x
+
+*Use other versions at your own risk.*
+
 ## Motivation
 
 The official MongoDB driver for Node.js (https://github.com/mongodb/node-mongodb-native) leaves connection management to the user - this means to connect

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-flowtype": "^8.0.3",
         "flow-bin": "^0.108.0",
         "mocha": "^10.1.0",
-        "mongojs": "^3.0.0",
+        "mongojs": "^3.1.0",
         "nyc": "^14.1.1",
         "semantic-release": "^19.0.5"
       },
@@ -6040,9 +6040,10 @@
       "license": "MIT"
     },
     "node_modules/mongojs": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-3.1.0.tgz",
+      "integrity": "sha512-aXJ4xfXwx9s1cqtKTZ24PypXiWhIgvgENObQzCGbV4QBxEVedy3yuErhx6znk959cF2dOzL2ClgXJvIhfgkpIQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "each-series": "^1.0.0",
         "mongodb": "^3.3.2",
@@ -14939,7 +14940,9 @@
       }
     },
     "mongojs": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-3.1.0.tgz",
+      "integrity": "sha512-aXJ4xfXwx9s1cqtKTZ24PypXiWhIgvgENObQzCGbV4QBxEVedy3yuErhx6znk959cF2dOzL2ClgXJvIhfgkpIQ==",
       "dev": true,
       "requires": {
         "each-series": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-flowtype": "^8.0.3",
     "flow-bin": "^0.108.0",
     "mocha": "^10.1.0",
-    "mongojs": "^3.0.0",
+    "mongojs": "^3.1.0",
     "nyc": "^14.1.1",
     "semantic-release": "^19.0.5"
   }


### PR DESCRIPTION
Update documentation and testing to support only active mongodb versions. 

Other versions have been EOL for over a year.