### PR TITLE
fix: test for mongo 3.6.2 and 4.0

### DIFF
--- a/test/database.js
+++ b/test/database.js
@@ -183,7 +183,8 @@ describe('database', function() {
           roles: ['readWrite']
         });
       } catch(e) {
-        expect(e.code).to.equal(51003);
+        // Error codes for duplicate values are different between MongoDB 3.x. (11000) and 4.2.x (51003)
+        expect(e.code).to.be.oneOf([51003, 11000]);
         return;
       }
 


### PR DESCRIPTION
Updated test case which checks duplicate values to check both error codes that are used for v3 and v4 of mongodb