### PR TITLE
feat: adding nMatched for backwards compatibility

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -115,6 +115,7 @@ module.exports = class Collection {
           nModified: result.modifiedCount,
           nUpserted: result.upsertedCount,
           upserted: result.upsertedCount ? [{_id: result.upsertedId}] : null,
+          nMatched: result.matchedCount,
         });
       });
   }


### PR DESCRIPTION
Adding `nMatched` property to the update result that is reusing the `matchedCount` value that is used in mongodb 4.x