### PR TITLE
fix: database connect race condition

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -142,6 +142,10 @@ module.exports = class Database extends EventEmitter {
     }
 
     this._connecting = (async () => {
+      if (isThenable(this.connectionString)) {
+        const connectionString = await Promise.resolve(this.connectionString);
+        this.connectionString = connectionString;
+      } 
       if (typeof this.connectionString == 'string') {
         try {
           const client = await mongodb.MongoClient.connect(this.connectionString, Object.assign(this.options));
@@ -184,10 +188,6 @@ module.exports = class Database extends EventEmitter {
 
         this.emit('connect');
         return this.connection;
-      } else if (isThenable(this.connectionString)) {
-        const connectionString = await Promise.resolve(this.connectionString);
-        this.connectionString = connectionString;
-        return this.connect();
       }
     })();
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -141,57 +141,60 @@ module.exports = class Database extends EventEmitter {
       return this._connecting;
     }
 
-    this._connecting = (async () => {
-      if (isThenable(this.connectionString)) {
-        const connectionString = await Promise.resolve(this.connectionString);
-        this.connectionString = connectionString;
-      } 
-      if (typeof this.connectionString == 'string') {
-        try {
-          const client = await mongodb.MongoClient.connect(this.connectionString, Object.assign(this.options));
-          this.client = client;
-          this.connection = client.db(this.options.dbName);
-
-          this.features = {
-            useLegacyProjections: false
-          };
-
-          this.emit('connect');
-          return this.connection;
-        } catch (e) {
-          this.emit('error', e);
-          throw e;
-        }
-      } else if (typeof this.connectionString._getConnection === 'function') { // mongojs
-        return new Promise((resolve, reject) => {
-          this.connectionString._getConnection((err, connection, conn) => {
-            if (err) { return reject(err); }
-
-            this.connection = connection;
-
-            this.features = {
-              // Third argument conn is only sent in mongojs 3
-              useLegacyProjections: !conn
-            };
-
-            this.emit('connect');
-            resolve(this.connection);
-          });
-        });
-      } else if (this.connectionString instanceof Database) { // mongoist
-        const connection = await this.connectionString.connect();
-        this.connection = connection;
-
-        this.features = {
-          useLegacyProjections: false
-        };
-
-        this.emit('connect');
-        return this.connection;
-      }
-    })();
-
+    this._connecting = this.initializeConnection();
     return this._connecting;
+  }
+
+  async initializeConnection() {
+    try {
+      if (isThenable(this.connectionString)) {
+        this.connectionString = await Promise.resolve(this.connectionString);
+      }
+
+      if (typeof this.connectionString === 'string') {
+        return await this.connectToMongoClient();
+      } else if (typeof this.connectionString._getConnection === 'function') {
+        return await this.connectToMongojs();
+      } else if (this.connectionString instanceof Database) {
+        return await this.connectToMongoist();
+      }
+    } catch (error) {
+      this._connecting = null; // Reset _connecting on error
+      this.emit('error', error);
+      throw error; // Rethrow the error for handling
+    }
+  }
+  
+  async connectToMongoClient() {
+    const client = await mongodb.MongoClient.connect(this.connectionString, Object.assign(this.options));
+    this.client = client;
+    this.connection = client.db(this.options.dbName);
+    this.features = { useLegacyProjections: false };
+    this.emit('connect');
+    return this.connection;
+  }
+
+  connectToMongojs() {
+    return new Promise((resolve, reject) => {
+      this.connectionString._getConnection((err, connection, conn) => {
+        if (err) {
+          return reject(err);
+        }
+
+        this.connection = connection;
+        this.features = { useLegacyProjections: !conn };
+        this.emit('connect');
+        resolve(this.connection);
+      });
+    });
+  }
+
+  async connectToMongoist() {
+    const connection = await this.connectionString.connect();
+    this.connection = connection;
+    this.features = { useLegacyProjections: false };
+    this.emit('connect');
+    return this.connection;
   }
 
   close(force) {

--- a/lib/database.js
+++ b/lib/database.js
@@ -55,6 +55,9 @@ module.exports = class Database extends EventEmitter {
     this.connection = null;
     this.features = null;
     this.client = null;
+
+    // Defining a var that is used to stop race condtions when calling connect multiple times
+    this._connecting = null;
   }
 
   createCollection(name, opts) {
@@ -133,46 +136,46 @@ module.exports = class Database extends EventEmitter {
       return Promise.resolve(this.connection);
     }
 
-    if (typeof this.connectionString == 'string') {
-          return mongodb.MongoClient
-            .connect(this.connectionString, Object.assign(this.options))
-            .then(client => {
+    if (this._connecting) {
+      // Race condition, return the promise
+      return this._connecting;
+    }
 
-              this.client = client;
-              this.connection = client.db(this.options.dbName);
-
-              this.features = {
-                useLegacyProjections: false
-              };
-
-              this.emit('connect');
-
-              return this.connection;
-            })
-            .catch(e => {
-              this.emit('error', e);
-
-              throw e;
-            });
-    } else if (typeof this.connectionString._getConnection === 'function') { // mongojs
-      return new Promise((resolve, reject) => {
-        this.connectionString._getConnection((err, connection, conn) => {
-          if (err) { return reject(err); }
-
-          this.connection = connection;
+    this._connecting = (async () => {
+      if (typeof this.connectionString == 'string') {
+        try {
+          const client = await mongodb.MongoClient.connect(this.connectionString, Object.assign(this.options));
+          this.client = client;
+          this.connection = client.db(this.options.dbName);
 
           this.features = {
-            // Third argument conn is only sent in mongojs 3
-            useLegacyProjections: !conn
+            useLegacyProjections: false
           };
 
           this.emit('connect');
+          return this.connection;
+        } catch (e) {
+          this.emit('error', e);
+          throw e;
+        }
+      } else if (typeof this.connectionString._getConnection === 'function') { // mongojs
+        return new Promise((resolve, reject) => {
+          this.connectionString._getConnection((err, connection, conn) => {
+            if (err) { return reject(err); }
 
-          resolve(this.connection);
+            this.connection = connection;
+
+            this.features = {
+              // Third argument conn is only sent in mongojs 3
+              useLegacyProjections: !conn
+            };
+
+            this.emit('connect');
+            resolve(this.connection);
+          });
         });
-      });
-    } else if (this.connectionString instanceof Database) { // mongoist
-      return this.connectionString.connect().then((connection) => {
+      } else if (this.connectionString instanceof Database) { // mongoist
+        const connection = await this.connectionString.connect();
         this.connection = connection;
 
         this.features = {
@@ -180,16 +183,15 @@ module.exports = class Database extends EventEmitter {
         };
 
         this.emit('connect');
-
         return this.connection;
-      });
-    } else if (isThenable(this.connectionString)) {
-      return Promise.resolve(this.connectionString)
-        .then(connectionString => {
-          this.connectionString = connectionString;
-          return this.connect();
-        });
-    }
+      } else if (isThenable(this.connectionString)) {
+        const connectionString = await Promise.resolve(this.connectionString);
+        this.connectionString = connectionString;
+        return this.connect();
+      }
+    })();
+
+    return this._connecting;
   }
 
   close(force) {

--- a/test/database.js
+++ b/test/database.js
@@ -129,8 +129,6 @@ describe('database', function() {
       await cannotConnect.xyz.find();
     } catch (e) {
       expect(errorEvent).to.exist;
-
-      cannotConnect.close();
       return;
     }
 
@@ -336,4 +334,11 @@ describe('database', function() {
     const dbStats = await db.adminCommand({ dbStats: 1 });
     expect(dbStats.db).to.equal('admin');
   })
+
+  it('should handle race conditions correctly', async () => {
+    const connectPromises = [db.connect(), db.connect(), db.connect()];
+    const connections = await Promise.all(connectPromises);
+
+    expect(new Set(connections).size).to.equal(1);
+  });
 });


### PR DESCRIPTION
When using db calls like find, update, insert. Under the hood it calls .connect() for almost every operation that you trigger, and connect spawns a promise to create a connection object. However the "singleton" condition (checking connection) in the library is not valid and if you don't wait until DB is connected and spawn many commands - you can get many DB connections created in parallel.

Fix for this was to setup a new value that holds the promise for a single connection and keeps returning that if the connection is still not established