### PR TITLE
feat(deps): bump mongodb to support mongo v7.0 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x]
-        mongodb-version: ["3.6.2", "4.0", "4.2", "4.4", "5.0", "6.0"]
+        mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master, alpha, beta, main, next, next-major ]
+    branches: [master, alpha, beta, main, next, next-major]
 
 jobs:
   test:
@@ -12,35 +12,35 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        mongodb-version: ['3.6.2','4.0', '4.2', '4.4', '5.0', '6.0']
+        node-version: [16.x, 18.x]
+        mongodb-version: ["3.6.2", "4.0", "4.2", "4.4", "5.0", "6.0"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - name: Start MongoDB
-      uses: supercharge/mongodb-github-action@1.6.0        
-      with:
-        mongodb-version: ${{ matrix.mongodb-version }}      
-    - run: npm ci
-    - run: npm run lint && npm run test
-    - name: Coveralls Parallel
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: run-${{ matrix.node-version }}-${{ matrix.mongodb-version }}
-        parallel: true
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.6.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+      - run: npm ci
+      - run: npm run lint && npm run test
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.node-version }}-${{ matrix.mongodb-version }}
+          parallel: true
 
   finish:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -13,28 +13,26 @@ The official MongoDB driver for Node.js (https://github.com/mongodb/node-mongodb
 to a mongodb database this boilerplate code is needed
 
 ```javascript
-const { MongoClient } = require('mongodb');
+const { MongoClient } = require("mongodb");
 
-MongoClient
-  .connect('mongodb://localhost:27017/myproject')
-  .then(connection => {
-
+MongoClient.connect("mongodb://localhost:27017/myproject").then(
+  (connection) => {
     connection.close();
-  });
+  }
+);
 ```
 
 Due to the asynchronous nature of `connect`, a connection that is used everywhere in an application is not that easy to export from a module.
 
 ```javascript
-const { MongoClient } = require('mongodb');
+const { MongoClient } = require("mongodb");
 
-MongoClient
-  .connect('mongodb://localhost:27017/myproject')
-  .then(connection => {
-
+MongoClient.connect("mongodb://localhost:27017/myproject").then(
+  (connection) => {
     // THIS WILL NOT WORK AS EXPECTED!!!
     module.exports = connection;
-  });
+  }
+);
 ```
 
 Mongoist solves this problem by managing the connection internally in a lazy fashion. With mongoist you can create a `db.js` module exporting a
@@ -59,8 +57,8 @@ _Please note: Any line in the examples that uses the await keyword should be cal
 ### Connecting
 
 ```javascript
-const mongoist = require('mongoist');
-const db = mongoist(connectionString, connectionOptions)
+const mongoist = require("mongoist");
+const db = mongoist(connectionString, connectionOptions);
 ```
 
 The `connectionString` and `connectionOptions` are passed to the underlying official mongodb driver.
@@ -81,8 +79,7 @@ async function findDocuments() {
 }
 
 // We need to call the async function this way since top level await keyword is not allowed in JavaScript
-findDocuments().then(() => console.log('Done querying mongodb'));
-
+findDocuments().then(() => console.log("Done querying mongodb"));
 ```
 
 #### Connection Management
@@ -121,23 +118,32 @@ const documentsCursor = db.mycollection.findAsCursor();
 const document = await documentsCursor.next();
 
 // find everything in mycollection, but sort by name
-const sortedDocuments = await db.mycollection.findAsCursor().sort({name: 1}).toArray();
+const sortedDocuments = await db.mycollection
+  .findAsCursor()
+  .sort({ name: 1 })
+  .toArray();
 
 // find a document using a native ObjectId
-const documentById = await db.mycollection.findOne({ _id: mongoist.ObjectId('523209c4561c640000000001') });
+const documentById = await db.mycollection.findOne({
+  _id: mongoist.ObjectId("523209c4561c640000000001"),
+});
 
 // Update all documents named 'mathias' and increment their level
-const resultUpdate = await db.mycollection.update({name: 'mathias'}, {$inc: {level: 1}}, {multi: true});
+const resultUpdate = await db.mycollection.update(
+  { name: "mathias" },
+  { $inc: { level: 1 } },
+  { multi: true }
+);
 
 // find one named 'mathias', tag him as a contributor and return the modified doc
 const resultFindAndModify = await db.mycollection.findAndModify({
-  query: { name: 'mathias' },
-  update: { $set: { tag: 'maintainer' } },
-  new: true
+  query: { name: "mathias" },
+  update: { $set: { tag: "maintainer" } },
+  new: true,
 });
 
 // use the save function to just save a document
-const doc = await db.mycollection.save({created: 'just now'});
+const doc = await db.mycollection.save({ created: "just now" });
 ```
 
 ### Cursor Operations
@@ -149,15 +155,15 @@ provides the operations `findAsCursor` and `aggregateAsCursor` to return a curso
 ## Bulk updates
 
 ```javascript
-var bulk = db.a.initializeOrderedBulkOp()
-bulk.find({type: 'water'}).update({$set: {level: 1}})
-bulk.find({type: 'water'}).update({$inc: {level: 2}})
-bulk.insert({name: 'Spearow', type: 'flying'})
-bulk.insert({name: 'Pidgeotto', type: 'flying'})
-bulk.insert({name: 'Charmeleon', type: 'fire'})
-bulk.find({type: 'flying'}).removeOne()
-bulk.find({type: 'fire'}).remove()
-bulk.find({type: 'water'}).updateOne({$set: {hp: 100}})
+var bulk = db.a.initializeOrderedBulkOp();
+bulk.find({ type: "water" }).update({ $set: { level: 1 } });
+bulk.find({ type: "water" }).update({ $inc: { level: 2 } });
+bulk.insert({ name: "Spearow", type: "flying" });
+bulk.insert({ name: "Pidgeotto", type: "flying" });
+bulk.insert({ name: "Charmeleon", type: "fire" });
+bulk.find({ type: "flying" }).removeOne();
+bulk.find({ type: "fire" }).remove();
+bulk.find({ type: "water" }).updateOne({ $set: { hp: 100 } });
 
 await bulk.execute();
 // done...
@@ -166,17 +172,17 @@ await bulk.execute();
 ### Events
 
 ```js
-const db = mongoist('mongodb://localhost/mydb')
+const db = mongoist("mongodb://localhost/mydb");
 
 // Emitted if no db connection could be established
-db.on('error', function (err) {
-  console.log('database error', err)
+db.on("error", function (err) {
+  console.log("database error", err);
 });
 
 // Emitted if a db connection was established
-db.on('connect', function () {
-  console.log('database connected')
-})
+db.on("connect", function () {
+  console.log("database connected");
+});
 ```
 
 ### Database commands
@@ -184,14 +190,14 @@ db.on('connect', function () {
 With mongoist you can run database commands just like with the mongo shell using `db.runCommand()`
 
 ```js
-const result = await db.runCommand({ping: 1});
-console.log('we\'re up');
+const result = await db.runCommand({ ping: 1 });
+console.log("we're up");
 ```
 
 or `db.collection.runCommand()`
 
 ```js
-const result = await db.things.runCommand('count');
+const result = await db.things.runCommand("count");
 console.log(result);
 ```
 
@@ -199,7 +205,7 @@ Similarly, you can use `db.adminCommand()` to run a command on the `admin` datab
 MongoDB cluster or instance you're connected to:
 
 ```js
-const result = await db.adminCommand({currentOp: 1});
+const result = await db.adminCommand({ currentOp: 1 });
 console.log(result);
 ```
 
@@ -208,7 +214,7 @@ console.log(result);
 Mongoist can connect to a mongo replication set by providing a connection string with multiple hosts
 
 ```js
-const db = mongoist('rs-1.com,rs-2.com,rs-3.com/mydb?slaveOk=true');
+const db = mongoist("rs-1.com,rs-2.com,rs-3.com/mydb?slaveOk=true");
 ```
 
 For more detailed information about replica sets see [the mongo replication docs](http://www.mongodb.org/display/DOCS/Replica+Sets)
@@ -223,16 +229,14 @@ Mongoist exposes the prototypes of `Database`, `Collection`, `Cursor` and `Bulk`
 to provide basic support for mocking, stubbing data access in tests.
 
 ```js
-const mongoist = require('mongoist');
+const mongoist = require("mongoist");
 
 // Override collection find behavior to always return { foo: 'bar' }
-mongoist.Collection.prototype.find = function() {
-  return [
-    { foo: 'bar' }
-  ]
-}
+mongoist.Collection.prototype.find = function () {
+  return [{ foo: "bar" }];
+};
 
-const db = mongoist('test');
+const db = mongoist("test");
 console.log(db.a.find({}));
 
 // Will print out [{ foo: 'bar' }]
@@ -256,13 +260,13 @@ See https://docs.mongodb.org/manual/reference/method/db.collection.aggregate/
 
 Supported options:
 
-Field | Type | Description
--- | -- | --
-limit | integer | Optional. The maximum number of documents to count.
-skip | integer | Optional. The number of documents to skip before counting.
-hint | string or document | Optional. An index name hint or specification for the query.
-maxTimeMS | integer | Optional. The maximum amount of time to allow the query to run.
-collation | document | Optional.
+| Field     | Type               | Description                                                     |
+| --------- | ------------------ | --------------------------------------------------------------- |
+| limit     | integer            | Optional. The maximum number of documents to count.             |
+| skip      | integer            | Optional. The number of documents to skip before counting.      |
+| hint      | string or document | Optional. An index name hint or specification for the query.    |
+| maxTimeMS | integer            | Optional. The maximum amount of time to allow the query to run. |
+| collation | document           | Optional.                                                       |
 
 See https://docs.mongodb.org/manual/reference/method/db.collection.count/
 
@@ -322,7 +326,7 @@ See https://docs.mongodb.org/manual/reference/method/db.collection.getIndexes/
 
 See https://docs.mongodb.org/manual/reference/method/db.collection.group/
 
-**Deprecation Notice**: Deprecated since version 3.4: Mongodb 3.4 deprecates the db.collection.group() method. Use db.collection.aggregate() with the $group stage or db.collection.mapReduce() instead.
+**Deprecation Notice**: Deprecated since version 3.4: Mongodb 3.4 deprecates the db.collection.group() method. Use db.collection.aggregate() with the $group stage instead.
 
 #### `db.collection.insert(docOrDocs, options)`
 
@@ -331,10 +335,6 @@ See https://docs.mongodb.com/manual/reference/method/db.collection.insert/
 #### `db.collection.isCapped()`
 
 See https://docs.mongodb.com/manual/reference/method/db.collection.isCapped/
-
-#### `db.collection.mapReduce(map, reduce, options)`
-
-See https://docs.mongodb.com/manual/reference/method/db.collection.mapReduce/
 
 #### `db.collection.reIndex()`
 
@@ -387,12 +387,14 @@ Get the name of the collection.
 Cursor implements a readable stream. For example, you can pipe a cursor to a writeable stream.
 
 ```javascript
-db.someCollection.findAsCursor()
+db.someCollection
+  .findAsCursor()
   .pipe(writeableStream)
-  .on('finish', () => {
-    console.log('all documents piped to writeableStream');
+  .on("finish", () => {
+    console.log("all documents piped to writeableStream");
   });
 ```
+
 #### `cursor.addCursorFlag(flag, value)`
 
 See https://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#addCursorFlag
@@ -492,7 +494,6 @@ See https://docs.mongodb.com/manual/reference/method/db.getLastErrorObj/
 #### `db.runCommand(command)`
 
 See https://docs.mongodb.com/manual/reference/method/db.runCommand/
-
 
 #### `db.adminCommand(command)`
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -175,15 +175,7 @@ module.exports = class Collection {
     return this.runCommand('collStats');
   }
 
-  /** @deprecated Please use the aggregation pipeline instead */
-  mapReduce(map, reduce, opts) {
-    opts = opts || {};
-
-    return this
-      .connect()
-      .then(connection => connection.mapReduce(map, reduce, opts));
-  }
-
+ 
   runCommand(cmd, opts) {
     opts = opts || {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
-        "mongodb": "^4.8.0"
+        "mongodb": "^6.15.0"
       },
       "devDependencies": {
         "@babel/core": "^7.7.2",
@@ -2100,6 +2100,14 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
+      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2550,14 +2558,6 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
-      "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
-      "dependencies": {
-        "undici-types": "~6.11.1"
-      }
-    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -2582,11 +2582,10 @@
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "dependencies": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -2883,25 +2882,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -3014,37 +2994,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3803,14 +3757,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/deprecation": {
@@ -5190,25 +5136,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5389,6 +5316,8 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -5400,12 +5329,16 @@
     "node_modules/ip-address/node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -6230,8 +6163,7 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -6643,40 +6575,68 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.0.tgz",
-      "integrity": "sha512-a0eVzm1e1kxwnzJV1wZXIS54KegM2y6wXTXOGTSAxr/E2YOUkl/zGBHNSI4z+6z+YQtVdzDqy1nJ4n5MxYJRnQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.15.0.tgz",
+      "integrity": "sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==",
       "dependencies": {
-        "bson": "^4.6.5",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.5.2",
-        "socks": "^2.6.2"
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=16.20.1"
       },
-      "optionalDependencies": {
-        "saslprep": "^1.0.3"
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
+      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
@@ -6688,15 +6648,15 @@
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/mongojs": {
@@ -10053,9 +10013,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -10610,6 +10570,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -10988,6 +10949,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -10997,6 +10960,8 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -11038,7 +11003,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -11692,11 +11656,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
-      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -13959,6 +13918,14 @@
       "dev": true,
       "optional": true
     },
+    "@mongodb-js/saslprep": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
+      "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14303,14 +14270,6 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
-    "@types/node": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
-      "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
-      "requires": {
-        "undici-types": "~6.11.1"
-      }
-    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -14335,11 +14294,10 @@
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
     },
     "@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "requires": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -14571,11 +14529,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -14671,21 +14624,9 @@
       }
     },
     "bson": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -15267,11 +15208,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -16338,11 +16274,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -16483,6 +16414,8 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -16491,12 +16424,16 @@
         "jsbn": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-          "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+          "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+          "optional": true,
+          "peer": true
         },
         "sprintf-js": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -17140,8 +17077,7 @@
     "memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "meow": {
       "version": "8.1.2",
@@ -17463,32 +17399,30 @@
       "dev": true
     },
     "mongodb": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.0.tgz",
-      "integrity": "sha512-a0eVzm1e1kxwnzJV1wZXIS54KegM2y6wXTXOGTSAxr/E2YOUkl/zGBHNSI4z+6z+YQtVdzDqy1nJ4n5MxYJRnQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.15.0.tgz",
+      "integrity": "sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==",
       "requires": {
-        "bson": "^4.6.5",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.5.2",
-        "saslprep": "^1.0.3",
-        "socks": "^2.6.2"
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "requires": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       },
       "dependencies": {
         "tr46": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
+          "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
           "requires": {
-            "punycode": "^2.1.1"
+            "punycode": "^2.3.1"
           }
         },
         "webidl-conversions": {
@@ -17497,11 +17431,11 @@
           "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
         },
         "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "version": "14.2.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+          "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
           "requires": {
-            "tr46": "^3.0.0",
+            "tr46": "^5.1.0",
             "webidl-conversions": "^7.0.0"
           }
         }
@@ -19887,9 +19821,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "q": {
       "version": "1.5.1",
@@ -20295,6 +20229,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -20587,12 +20522,16 @@
     "smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "optional": true,
+      "peer": true
     },
     "socks": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -20626,7 +20565,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
       }
@@ -21147,11 +21085,6 @@
       "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
       "dev": true,
       "optional": true
-    },
-    "undici-types": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
-      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/mongoist/mongoist#readme",
   "dependencies": {
     "debug": "^4.3.4",
-    "mongodb": "^4.8.0"
+    "mongodb": "^6.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=16.20.1"
   },
   "scripts": {
     "test": "nyc --reporter=lcov mocha --recursive --require @babel/polyfill --require @babel/register",

--- a/test/collection.js
+++ b/test/collection.js
@@ -238,26 +238,6 @@ describe('collection', function() {
     expect(collectionToString).to.equal('a');
   });
 
-  it('should run map reduce', async() => {
-    function map() {
-      /* eslint-disable no-undef */
-      emit(this.type, this.level)
-      /* eslint-enable no-undef */
-    }
-
-    function reduce(key, values) {
-      return Array.sum(values)
-    }
-
-    await db.a.mapReduce(map, reduce, {
-      query: { type: 'water' },
-      out: 'levelSum'
-    });
-
-    const levelSum = await db.levelSum.findOne();
-    expect(levelSum._id).to.equal('water');
-    expect(levelSum.value).to.equal(30);
-  });
 
   it('should ensure, create list and drop indexes and reIndex for a collection', async() => {
     await db.a.ensureIndex({type: 1});


### PR DESCRIPTION
This pull request introduces updates to the codebase to support MongoDB versions 7 and 8. 

This pull request updates the MongoDB dependency from version 4.8.0 to 6.15.0, ensuring compatibility with the latest versions (v7 and v8). Additionally, it removes deprecated `mapReduce` methods in the collection module, promoting the use of aggregation pipelines instead. 

- [x] The code examples in the README have been updated for consistency, clarity, and alignment with the new MongoDB version. 


BREAKING CHANGE:

* The mapReduce() function have been removed aligning with the new MongoDB standards. But also was marked as deprecated 