### PR TITLE
fix: release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           extra_plugins: |


### PR DESCRIPTION


Updated the GitHub Actions workflow to replace secrets.GH_TOKEN with secrets.GITHUB_TOKEN in the semantic-release job.

**Why:**

GH_TOKEN is not a built-in secret in GitHub Actions — it only works if manually configured in the repository settings.
GITHUB_TOKEN is automatically provided by GitHub and scoped to the current workflow run. It’s the recommended way to authenticate with the GitHub API and is supported out-of-the-box by @semantic-release.

This change ensures that the release pipeline can run without requiring custom secrets, improving maintainability and reliability.

**Impact:**
	•	Release automation should now run correctly using GitHub’s built-in authentication.
	•	No functional changes to the release logic itself.
