### PR TITLE
fix: update code style and add support for ObjectId without constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,26 @@
-const mongodb = require('mongodb');
-const Database = require('./lib/database');
-const Collection = require('./lib/collection');
-const Cursor = require('./lib/cursor');
-const Bulk = require('./lib/bulk');
+const mongodb = require("mongodb");
+const Database = require("./lib/database");
+const Collection = require("./lib/collection");
+const Cursor = require("./lib/cursor");
+const Bulk = require("./lib/bulk");
 
 function isValidCollectionName(name) {
-  return typeof name === 'string' && name &&
-    !(name.includes('$') || name.includes('\0') || name.startsWith('system.'));
+  return (
+    typeof name === "string" &&
+    name &&
+    !(name.includes("$") || name.includes("\0") || name.startsWith("system."))
+  );
 }
 
-module.exports = function(connectionString, options) {
+module.exports = function (connectionString, options) {
   const db = new Database(connectionString, options);
   const dbMethods = Object.create(null);
 
   return new Proxy(db, {
-    get: function(obj, prop) {
+    get: function (obj, prop) {
       const dbProp = obj[prop];
 
-      if (typeof dbProp === 'function') {
+      if (typeof dbProp === "function") {
         //lazily cache function bound to underlying db
         dbMethods[prop] = dbMethods[prop] || dbProp.bind(db);
         return dbMethods[prop];
@@ -28,29 +31,37 @@ module.exports = function(connectionString, options) {
       }
 
       return dbProp;
-    }
+    },
   });
+};
+
+// support for ObjectId without constructor
+function ObjectId(...args) {
+  if (!(this instanceof mongodb.ObjectId)) {
+    return new mongodb.ObjectId(...args);
+  }
+  return mongodb.ObjectId.apply(this, args);
 }
 
 // expose prototypes
-module.exports.Database = Database
-module.exports.Collection = Collection
-module.exports.Cursor = Cursor
-module.exports.Bulk = Bulk
+module.exports.Database = Database;
+module.exports.Collection = Collection;
+module.exports.Cursor = Cursor;
+module.exports.Bulk = Bulk;
 
 // expose bson stuff visible in the shell
-module.exports.Binary = mongodb.Binary
-module.exports.Code = mongodb.Code
-module.exports.DBRef = mongodb.DBRef
-module.exports.Double = mongodb.Double
-module.exports.Long = mongodb.Long
-module.exports.NumberLong = mongodb.Long // Alias for shell compatibility
-module.exports.MinKey = mongodb.MinKey
-module.exports.MaxKey = mongodb.MaxKey
-module.exports.ObjectID = mongodb.ObjectID
-module.exports.ObjectId = mongodb.ObjectId
-module.exports.Symbol = mongodb.Symbol
-module.exports.Timestamp = mongodb.Timestamp
+module.exports.Binary = mongodb.Binary;
+module.exports.Code = mongodb.Code;
+module.exports.DBRef = mongodb.DBRef;
+module.exports.Double = mongodb.Double;
+module.exports.Long = mongodb.Long;
+module.exports.NumberLong = mongodb.Long; // Alias for shell compatibility
+module.exports.MinKey = mongodb.MinKey;
+module.exports.MaxKey = mongodb.MaxKey;
+module.exports.ObjectID = ObjectId;
+module.exports.ObjectId = ObjectId;
+module.exports.Symbol = mongodb.Symbol;
+module.exports.Timestamp = mongodb.Timestamp;
 
 // Add support for default ES6 module imports
-module.exports.default = module.exports
+module.exports.default = module.exports;

--- a/index.js
+++ b/index.js
@@ -37,11 +37,10 @@ module.exports = function (connectionString, options) {
 
 // support for ObjectId without constructor
 function ObjectId(...args) {
-  if (!(this instanceof mongodb.ObjectId)) {
-    return new mongodb.ObjectId(...args);
-  }
-  return mongodb.ObjectId.apply(this, args);
+  return new mongodb.ObjectId(...args);
 }
+Object.setPrototypeOf(ObjectId, mongodb.ObjectId);
+ObjectId.prototype = mongodb.ObjectId.prototype;
 
 // expose prototypes
 module.exports.Database = Database;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "semantic-release": "^19.0.5"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/test/collection.js
+++ b/test/collection.js
@@ -347,4 +347,20 @@ describe("collection", function () {
     await mockDb.b.insert({ foo: "bar" });
     await mockDb.b.insert({ foo: "baz" });
   });
+
+  it("should support ObjectId without constructor", async () => {
+    const id = mongoist.ObjectId();
+    await db.a.insert({ _id: id });
+    const docs = await db.a.find({ _id: id });
+    expect(docs).to.have.length(1);
+    console.log(typeof docs[0]._id);
+  });
+
+  it("should support ObjectId with constructor", async () => {
+    const id = new mongoist.ObjectId();
+    await db.a.insert({ _id: id });
+    const docs = await db.a.find({ _id: id });
+    expect(docs).to.have.length(1);
+    console.log(typeof docs[0]._id);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -48,5 +48,13 @@ describe("database", function () {
       const id = new mongoist.ObjectId(hexString);
       expect(id.toString()).to.equal(hexString);
     });
+
+    it("should have same type as mongo ObjectId", () => {
+      const mongoObjectId = require("mongodb").ObjectId;
+      const mongoistObjectId = mongoist.ObjectId;
+
+      expect(mongoistObjectId).to.equal(mongoObjectId);
+      expect(typeof mongoistObjectId).to.equal(typeof mongoObjectId);
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -50,11 +50,10 @@ describe("database", function () {
     });
 
     it("should have same type as mongo ObjectId", () => {
-      const mongoObjectId = require("mongodb").ObjectId;
-      const mongoistObjectId = mongoist.ObjectId;
+      const mongoistObjectId = mongoist.ObjectId();
 
-      expect(mongoistObjectId).to.equal(mongoObjectId);
-      expect(typeof mongoistObjectId).to.equal(typeof mongoObjectId);
+      expect(mongoistObjectId instanceof require("mongodb").ObjectId).to.be
+        .true;
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,31 +1,52 @@
-const { expect } = require('chai');
-const dropMongoDbCollections = require('drop-mongodb-collections');
-const mongoist = require('../');
+const { expect } = require("chai");
+const dropMongoDbCollections = require("drop-mongodb-collections");
+const mongoist = require("../");
+const connectionString = "mongodb://localhost:27017/test";
 
-const connectionString = 'mongodb://localhost:27017/test';
-
-describe('database', function() {
+describe("database", function () {
   this.timeout(10000);
 
   beforeEach(dropMongoDbCollections(connectionString));
 
-  it('should not proxy symbols to collections', () => {
-    if (typeof Symbol.toStringTag == 'undefined') {
+  it("should not proxy symbols to collections", () => {
+    if (typeof Symbol.toStringTag == "undefined") {
       // skip test if not defined
       return;
     }
 
-    const  db = mongoist(connectionString);
+    const db = mongoist(connectionString);
 
     const noCollection = db[Symbol.toStringTag];
 
     expect(noCollection).to.not.exist;
   });
 
-  it('should export prototypes', () => {
+  it("should export prototypes", () => {
     expect(mongoist.Database).to.exist;
     expect(mongoist.Collection).to.exist;
     expect(mongoist.Cursor).to.exist;
     expect(mongoist.Bulk).to.exist;
+    expect(mongoist.ObjectId).to.exist;
+    expect(mongoist.ObjectID).to.exist;
+  });
+
+  describe("ObjectId", () => {
+    it("should support ObjectId without constructor", () => {
+      const ObjectId = mongoist.ObjectId;
+      const id = ObjectId();
+      expect(id).to.exist;
+    });
+
+    it("should support ObjectId with constructor", () => {
+      const ObjectId = mongoist.ObjectId;
+      const id = new ObjectId();
+      expect(id).to.exist;
+    });
+
+    it("should handle string IDs", () => {
+      const hexString = "507f1f77bcf86cd799439011";
+      const id = new mongoist.ObjectId(hexString);
+      expect(id.toString()).to.equal(hexString);
+    });
   });
 });


### PR DESCRIPTION
fix: ensure ObjectId works correctly without constructor

This PR fixes a compatibility issue with `ObjectId` usage where calling it without the `new` keyword could lead to error. The fix ensures consistent behavior across different instantiation patterns.

#### Before:
```javascript
// Inconsistent behavior when called without 'new'
const id = ObjectId('507f1f77bcf86cd799439011');
```

#### After:
```javascript
// Both patterns now work correctly
const id1 = new ObjectId('507f1f77bcf86cd799439011');
const id2 = ObjectId('507f1f77bcf86cd799439011');
```

This change maintains backward compatibility while ensuring proper ObjectId instantiation in both constructor and function call patterns. No breaking changes are introduced.
